### PR TITLE
Improve the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,23 @@
 
 * 🚀 **Powerful.** Firebolt Core ships with all key performance and usability features of Firebolt's [managed Cloud data warehouse](https://www.firebolt.io/), including a state-of-the-art query optimizer, distributed query execution engine, Iceberg support, and many more.
 * 🆓 **Free to Use.** Firebolt Core is free to use, forever (see the [LICENSE](LICENSE.md) for details).
+* 📈 **No usage limits.** Firebolt Core does not not have any usage limits. Work on as much data as you want, run as many clusters as you want, run as many queries as you want.
+* 🛢️ **Postgres compliance:** Firebolt's SQL dialect is Postgres compliant. We offer powerful extensions for analytical workloads, such as lambda functions for array processing. For a complete reference, see the [SQL reference documentation](https://docs.firebolt.io/sql_reference/).
 * 🛠️ **Self-Contained.** Firebolt Core comes packaged as a single Docker image (`ghcr.io/firebolt-db/firebolt-core:preview-rc`) that contains everything needed to run it.
 * 🏠 **Self-Hosted.** You can deploy Firebolt Core anywhere you want, from your personal workstation to large on-premise clusters or VPCs.
-* 📊 **First-Class Support** with [documentation](https://docs.firebolt.io/firebolt-core), updates, and active [community support via GitHub Discussions](https://github.com/firebolt-db/firebolt-core/discussions). We encourage you to join the conversation!
+* 📊 **First-Class support** with [documentation](https://docs.firebolt.io/firebolt-core), updates, and active [community support via GitHub Discussions](https://github.com/firebolt-db/firebolt-core/discussions). We encourage you to join the conversation!
 * 🤖 **AI-ready architecture** optimized for modern data and ML applications.
-* 🔄 **Workload compatibility** - many workloads run interchangeably with [managed Firebolt](https://www.firebolt.io/).
 * 🎯 **Designed for demanding applications:** Powering real-time analytics, embedded analytics, and large-scale data processing workloads.
-* 🛢️ **SQL Standard Compliance:** Firebolt's SQL dialect is highly compatible with Postgres, offering powerful extensions for analytical workloads. For a complete reference, see the [SQL reference documentation](https://docs.firebolt.io/sql_reference/).
+* 🔄 **Workload compatibility** - many workloads run interchangeably with [managed Firebolt](https://www.firebolt.io/).
 
 ## Get Started
 
-Start a single-node Core cluster with:
+Start Core on your machine with:
+```bash
+bash <(curl https://get-core.firebolt.io/)
+```
+
+If you want to work with Docker directly, you can also run:
 
 ```bash
 docker run -it --rm \

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@
 * 🚀 **Powerful.** Firebolt Core ships with all key performance and usability features of Firebolt's [managed Cloud data warehouse](https://www.firebolt.io/), including a state-of-the-art query optimizer, distributed query execution engine, Iceberg support, and many more.
 * 🆓 **Free to use.** Firebolt Core is free to use, forever (see the [LICENSE](LICENSE.md) for details).
 * 📈 **No usage limits.** Firebolt Core does not not have any usage limits. Work on as much data as you want, run as many clusters as you want, run as many queries as you want.
-* 🛢️ **Postgres compliance:** Firebolt's SQL dialect is Postgres compliant. We offer powerful extensions for analytical workloads, such as lambda functions for array processing. For a complete reference, see the [SQL reference documentation](https://docs.firebolt.io/sql_reference/).
+* 🛢️ **Postgres compliant.** Firebolt's SQL dialect is Postgres compliant. We offer powerful extensions for analytical workloads, such as lambda functions for array processing. For a complete reference, see the [SQL reference documentation](https://docs.firebolt.io/sql_reference/).
 * 🛠️ **Self-contained.** Firebolt Core comes packaged as a single Docker image (`ghcr.io/firebolt-db/firebolt-core:preview-rc`) that contains everything needed to run it.
 * 🏠 **Self-hosted.** You can deploy Firebolt Core anywhere you want, from your personal workstation to large on-premise clusters or VPCs.
 * 📊 **First-class support** with [documentation](https://docs.firebolt.io/firebolt-core), updates, and active [community support via GitHub Discussions](https://github.com/firebolt-db/firebolt-core/discussions). We encourage you to join the conversation!
 * 🤖 **AI-ready architecture** optimized for modern data and ML applications.
-* 🎯 **Designed for demanding applications:** Powering real-time analytics, embedded analytics, and large-scale data processing workloads.
-* 🔄 **Workload compatibility** - many workloads run interchangeably with [managed Firebolt](https://www.firebolt.io/).
+* 🎯 **Designed for demanding applications.** Powering real-time analytics, embedded analytics, and large-scale data processing workloads.
+* 🔄 **Workload compatibility.** Many workloads run interchangeably with [managed Firebolt](https://www.firebolt.io/).
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@
 ## Key Features
 
 * 🚀 **Powerful.** Firebolt Core ships with all key performance and usability features of Firebolt's [managed Cloud data warehouse](https://www.firebolt.io/), including a state-of-the-art query optimizer, distributed query execution engine, Iceberg support, and many more.
-* 🆓 **Free to Use.** Firebolt Core is free to use, forever (see the [LICENSE](LICENSE.md) for details).
+* 🆓 **Free to use.** Firebolt Core is free to use, forever (see the [LICENSE](LICENSE.md) for details).
 * 📈 **No usage limits.** Firebolt Core does not not have any usage limits. Work on as much data as you want, run as many clusters as you want, run as many queries as you want.
 * 🛢️ **Postgres compliance:** Firebolt's SQL dialect is Postgres compliant. We offer powerful extensions for analytical workloads, such as lambda functions for array processing. For a complete reference, see the [SQL reference documentation](https://docs.firebolt.io/sql_reference/).
-* 🛠️ **Self-Contained.** Firebolt Core comes packaged as a single Docker image (`ghcr.io/firebolt-db/firebolt-core:preview-rc`) that contains everything needed to run it.
-* 🏠 **Self-Hosted.** You can deploy Firebolt Core anywhere you want, from your personal workstation to large on-premise clusters or VPCs.
-* 📊 **First-Class support** with [documentation](https://docs.firebolt.io/firebolt-core), updates, and active [community support via GitHub Discussions](https://github.com/firebolt-db/firebolt-core/discussions). We encourage you to join the conversation!
+* 🛠️ **Self-contained.** Firebolt Core comes packaged as a single Docker image (`ghcr.io/firebolt-db/firebolt-core:preview-rc`) that contains everything needed to run it.
+* 🏠 **Self-hosted.** You can deploy Firebolt Core anywhere you want, from your personal workstation to large on-premise clusters or VPCs.
+* 📊 **First-class support** with [documentation](https://docs.firebolt.io/firebolt-core), updates, and active [community support via GitHub Discussions](https://github.com/firebolt-db/firebolt-core/discussions). We encourage you to join the conversation!
 * 🤖 **AI-ready architecture** optimized for modern data and ML applications.
 * 🎯 **Designed for demanding applications:** Powering real-time analytics, embedded analytics, and large-scale data processing workloads.
 * 🔄 **Workload compatibility** - many workloads run interchangeably with [managed Firebolt](https://www.firebolt.io/).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 * 🚀 **Powerful.** Firebolt Core ships with all key performance and usability features of Firebolt's [managed Cloud data warehouse](https://www.firebolt.io/), including a state-of-the-art query optimizer, distributed query execution engine, Iceberg support, and many more.
 * 🆓 **Free to use.** Firebolt Core is free to use, forever (see the [LICENSE](LICENSE.md) for details).
-* 📈 **No usage limits.** Firebolt Core does not not have any usage limits. Work on as much data as you want, run as many clusters as you want, run as many queries as you want.
+* 📈 **No usage limits.** Firebolt Core has no usage limits. Process unlimited data, scale to as many nodes as you need, and run as many queries as you like.
 * 🛢️ **Postgres compliant.** Firebolt's SQL dialect is Postgres compliant. We offer powerful extensions for analytical workloads, such as lambda functions for array processing. For a complete reference, see the [SQL reference documentation](https://docs.firebolt.io/sql_reference/).
 * 🛠️ **Self-contained.** Firebolt Core comes packaged as a single Docker image (`ghcr.io/firebolt-db/firebolt-core:preview-rc`) that contains everything needed to run it.
 * 🏠 **Self-hosted.** You can deploy Firebolt Core anywhere you want, from your personal workstation to large on-premise clusters or VPCs.


### PR DESCRIPTION
This PR improves the README in a few ways:
1. Makes it clear that there are no usage limits - some DB community editions have caps on e.g. data sizes. We need to make it clear that there are zero restrictions for Core.
2. Reorders key features to have more important things further up top
3. Adds our nice one-liner to get started with Core - IMO that's more accessible than starting with the Docker command right away
