### PR TITLE
docs: mention how to use fb-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 </p>
 <p align="center">
   <a href="https://discord.gg/UpMPDHActM">
-    <img src="https://shields.io/discord/1376998505830420572" alt="Discord chat" />
-  </a>
+    <img src="https://shields.io/discord/1376998505830420572" alt="Discord chat"
+  /></a>
   <a href="https://docs.firebolt.io/firebolt-core" style="text-decoration: none"><img
     src="https://img.shields.io/badge/Core-docs-brightgreen"
     alt="Firebolt Core documentation"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bash <(curl https://get-core.firebolt.io/)
 If you want to work with Docker directly, you can also run:
 
 ```bash
-docker run -it --rm \
+docker run -i --rm \
         --ulimit memlock=8589934592:8589934592 \
         --security-opt seccomp=unconfined \
         -p 127.0.0.1:3473:3473 \
@@ -169,11 +169,17 @@ Resources for each node (either a local machine or a VM instance):
 
 ## Run Queries on Firebolt Core
 
-Any HTTP client can be used to submit queries to a Firebolt Core cluster. The following examples use [cURL](https://curl.se/).
+Any HTTP client can be used to submit queries to a Firebolt Core cluster.
+You can use [Firebolt CLI](https://github.com/firebolt-db/fb-cli) either as a stand-alone binary or by invoking the version running within the Core Docker container:
+```bash
+docker exec -ti firebolt-core fbcli "SELECT 42;"
+```
+
+The following examples use [cURL](https://curl.se/).
 
 ```bash
 # Simple select
-curl -s "http://localhost:3473" --data-binary "select 42";
+curl -s "http://localhost:3473" --data-binary "SELECT 42";
 ```
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME}-node-0
     # The Docker image from which to start the container.
     image: ghcr.io/firebolt-db/firebolt-core:preview-rc
+    pull_policy: always
     # Command-line arguments to pass to the Firebolt Core executable. Node index is 0 for the first node specified in the configuration.
     command: --node 0
     # Corresponds to the `--interactive` argument passed to `docker run`.

--- a/get-core.sh
+++ b/get-core.sh
@@ -22,7 +22,7 @@ banner() {
 # Docker image to pull
 DOCKER_IMAGE="ghcr.io/firebolt-db/firebolt-core:preview-rc"
 EXTERNAL_PORT=3473
-DOCKER_RUN_COMMAND="docker run -i --rm --ulimit memlock=8589934592:8589934592 --security-opt seccomp=unconfined -v ./firebolt-core-data:/firebolt-core/volume -p $EXTERNAL_PORT:3473 $DOCKER_IMAGE"
+DOCKER_RUN_COMMAND="docker run -i --rm --name firebolt-core --ulimit memlock=8589934592:8589934592 --security-opt seccomp=unconfined -v ./firebolt-core-data:/firebolt-core/volume -p $EXTERNAL_PORT:3473 $DOCKER_IMAGE"
 
 install_docker() {
     if docker info >/dev/null 2>&1; then
@@ -59,7 +59,7 @@ run_docker_image() {
             echo "[🔥] Running Firebolt Core Docker image with command: $DOCKER_RUN_COMMAND"
             echo "[🔥] Run SQL queries in another terminal with:"
             echo
-            echo "curl -s http://localhost:$EXTERNAL_PORT --data-binary 'select 42';"
+            echo "docker exec -ti firebolt-core fbcli"
             echo
             eval "$DOCKER_RUN_COMMAND"
             ;;
@@ -67,6 +67,10 @@ run_docker_image() {
             echo "[🔥] Firebolt Core is ready to be executed, you can do this by running the following command:"
             echo
             echo "$DOCKER_RUN_COMMAND"
+            echo
+            echo "And then in another terminal:"
+            echo
+            echo "docker exec -ti firebolt-core fbcli"
             echo
             ;;
 


### PR DESCRIPTION
This change suggests using https://github.com/firebolt-db/fb-cli where it makes sense because easier.

The pull policy is also changed to `always` because an outdated tag could exist on user's Docker host.