### PR TITLE
feat: expose Prometheus endpoint and add PodMonitor

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,7 @@ services:
       - "1717:1717"   # Inter-node communication channel for the storage service.
       - "3434:3434"   # Inter-node communication channel for the storage service.
       - "6500:6500"   # Inter-node communication channel for the metadata service.
+      - "9090:9090"   # Prometheus metrics.
     # Mount the configuration file at the expected location within the container. Additional storage mounts for persistent and temporary data could also be specified here.
     volumes:
       - ${PWD}/config.json:/firebolt-core/config.json:ro

--- a/helm/templates/podmonitor.yaml
+++ b/helm/templates/podmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "fbcore.fullname" . }}
+  labels:
+    {{- include "fbcore.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fbcore.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - interval: 15s
+      path: /metrics
+      port: metrics
+  podTargetLabels:
+    - app.kubernetes.io/name
+    - app.kubernetes.io/namespace

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -18,21 +18,24 @@ spec:
     - name: http-query
       port: 3473
       protocol: TCP
+    - name: health
+      port: 8122
+      protocol: TCP
+    - name: execp
+      port: 5678
+      protocol: TCP
+    - name: datacp
+      port: 16000
+      protocol: TCP
     - name: storage-manager
       port: 1717
       protocol: TCP
     - name: storage-agent
       port: 3434
       protocol: TCP
-    - name: execp
-      port: 5678
-      protocol: TCP
     - name: metadata
       port: 6500
       protocol: TCP
-    - name: health
-      port: 8122
-      protocol: TCP
-    - name: datacp
-      port: 16000
+    - name: metrics
+      port: 9090
       protocol: TCP

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -46,23 +46,26 @@ spec:
             - name: http-query
               containerPort: 3473
               protocol: TCP
+            - name: health
+              containerPort: 8122
+              protocol: TCP
+            - name: execp
+              containerPort: 5678
+              protocol: TCP
+            - name: datacp
+              containerPort: 16000
+              protocol: TCP
             - name: storage-manager
               containerPort: 1717
               protocol: TCP
             - name: storage-agent
               containerPort: 3434
               protocol: TCP
-            - name: execp
-              containerPort: 5678
-              protocol: TCP
             - name: metadata
               containerPort: 6500
               protocol: TCP
-            - name: health
-              containerPort: 8122
-              protocol: TCP
-            - name: datacp
-              containerPort: 16000
+            - name: metrics
+              containerPort: 9090
               protocol: TCP
           livenessProbe:
             periodSeconds: 5


### PR DESCRIPTION
This change will expose the Prometheus endpoint on standard port `9090` and add a PodMonitor which allows scraping the metrics.