### PR TITLE
feat: improve get-core.sh script

### DIFF
--- a/get-core.sh
+++ b/get-core.sh
@@ -49,7 +49,8 @@ ensure_docker_is_installed() {
 }
 
 check_docker_version() {
-        if [ "$(uname)" = "Darwin" ]; then
+    # Explicitly inform the user about the known io_uring issue in Docker Desktop 4.42.1 on Mac
+    if [ "$(uname)" = "Darwin" ]; then
         version=$(docker version | sed -n 's/.*Docker Desktop \([0-9.]*\).*/\1/p')
         if [ "$version" = "4.42.1" ]; then
             echo "[❌] Firebolt Core cannot run with Docker Desktop verion ${version} on Mac, as it contains a known bug: https://github.com/firebolt-db/firebolt-core/issues/9"


### PR DESCRIPTION
- Add a health check to the `get-core.sh` script, which checks if Core is able to receive queries.
- Add special handling for the newly discovered Docker version bug on Mac https://github.com/firebolt-db/firebolt-core/issues/9