### PR TITLE
feat: add option to run as non-root, set memlock ulimit in main container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
     command: --node 0
     # Corresponds to the `--interactive` argument passed to `docker run`.
     stdin_open: true
-    # explicitly run as root to mitigate volume-mount issues.
+    # explicitly run as root to mitigate volume-mount issues when using a non-root Core image.
     user: "0"
     # Corresponds to the `--tty` argument passed to `docker run`.
     tty: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,8 @@ services:
     command: --node 0
     # Corresponds to the `--interactive` argument passed to `docker run`.
     stdin_open: true
+    # explicitly run as root to mitigate volume-mount issues.
+    user: "0"
     # Corresponds to the `--tty` argument passed to `docker run`.
     tty: true
     # Corresponds to the `--security-opt seccomp=unconfined` argument passed to `docker run`.

--- a/helm/README.md
+++ b/helm/README.md
@@ -25,6 +25,7 @@ Firebolt Core on Kubernetes
 | image.repository | string | `"ghcr.io/firebolt-db/firebolt-core"` | use a custom ECR repository to pull the Docker image used by the pods |
 | image.tag | string | `nil` | use a custom Docker image tag; when unspecified the app version from chart will be used instead |
 | nodesCount | int | `1` | number of nodes to deploy |
+| podMonitor | bool | `false` | deploy a PodMonitor for Prometheus metrics scraping |
 | readiness | bool | `true` | readiness check on each pod |
 | resources | object | `{"limits":{"memory":"4Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | resources for each pod; at least 1 core is advised |
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -19,7 +19,6 @@ Firebolt Core on Kubernetes
 | deployment.storageSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | deployment.storageSpec.resources.limits.storage | string | `"1Gi"` |  |
 | deployment.storageSpec.resources.requests.storage | string | `"1Gi"` |  |
-| deployment.storageSpec.storageClassName | string | `"gp3"` |  |
 | deployment.terminationGracePeriodSeconds | int | `5` | give a few seconds of grace time on shutdown to allow queries to finish |
 | extraLabels | object | `{}` | extra labels to assign to each pod |
 | image.repository | string | `"ghcr.io/firebolt-db/firebolt-core"` | use a custom ECR repository to pull the Docker image used by the pods |

--- a/helm/README.md
+++ b/helm/README.md
@@ -14,8 +14,6 @@ Firebolt Core on Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| deployment.securityCapabilities | object | `{"add":["IPC_LOCK","SYS_NICE"]}` | security capabilities which will be used by each pod |
-| deployment.securityContext | object | `{"readOnlyRootFilesystem":false}` | security context which will be used by each pod |
 | deployment.storageSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | deployment.storageSpec.resources.limits.storage | string | `"1Gi"` |  |
 | deployment.storageSpec.resources.requests.storage | string | `"1Gi"` |  |
@@ -23,7 +21,9 @@ Firebolt Core on Kubernetes
 | extraLabels | object | `{}` | extra labels to assign to each pod |
 | image.repository | string | `"ghcr.io/firebolt-db/firebolt-core"` | use a custom ECR repository to pull the Docker image used by the pods |
 | image.tag | string | `nil` | use a custom Docker image tag; when unspecified the app version from chart will be used instead |
+| memlockSetup | bool | `true` | automatically attempt to set memlock limits on container startup; not necessary if your nodes already have a large enough memlock limit. |
 | nodesCount | int | `1` | number of nodes to deploy |
+| nonRoot | bool | `false` | enable non-root mode, requires a compatible Firebolt Core docker image |
 | podMonitor | bool | `false` | deploy a PodMonitor for Prometheus metrics scraping |
 | readiness | bool | `true` | readiness check on each pod |
 | resources | object | `{"limits":{"memory":"4Gi"},"requests":{"cpu":"1","memory":"4Gi"}}` | resources for each pod; at least 1 core is advised |

--- a/helm/templates/podmonitor.yaml
+++ b/helm/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podMonitor -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -16,3 +17,4 @@ spec:
   podTargetLabels:
     - app.kubernetes.io/name
     - app.kubernetes.io/namespace
+{{- end }}

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -23,6 +23,13 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ $.Values.deployment.terminationGracePeriodSeconds }}
+      {{- if .Values.nonRoot }}
+      securityContext:
+        fsGroup: 1111
+      {{- end }}
+      {{- if .Values.memlockSetup }}
+      shareProcessNamespace: true
+      {{- end }}
       containers:
         - name: core
           image: {{ $.Values.image.repository }}:{{  default $.Chart.AppVersion $.Values.image.tag }}
@@ -34,13 +41,39 @@ spec:
                   fieldPath: metadata.name
             - name: NODES_COUNT
               value: {{ .Values.nodesCount | quote }}
-          command: ["/bin/sh", "-c"]
+          command: ["/bin/bash", "-c"]
           tty: true
           stdin: true
           args:
             - |
-              export POD_INDEX="$(echo $POD_NAME | awk -F'-' '{print $NF}')"
+              REQUIRED_MEMLOCK_BYTES=8589934592 # 8GB
 
+              echo "[Setup] entrypoint PID: $BASHPID"
+              echo "$BASHPID" > /firebolt-core/volume/entrypoint.pid
+
+              {{- if .Values.memlockSetup }}
+              ## wait until memlock limits are changed by the helper container
+              CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
+              echo "[Setup] current soft memlock limit: $CURRENT_MEMLOCK_VALUE (will wait for limits to be upgraded if below 8GB)" 1>&2
+              while true; do
+                CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
+
+                if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
+                  break
+                else
+                    if [ "$CURRENT_MEMLOCK_VALUE" -lt "$REQUIRED_MEMLOCK_BYTES" ]; then
+                      sleep 0.2
+                    else
+                      echo "[Setup] current memlock limit ($CURRENT_MEMLOCK_VALUE bytes) is sufficient (>= 8GB)." 1>&2
+                      break
+                    fi
+                fi
+              done
+              {{- end }}
+              echo "[Setup] current memlock limit:" 1>&2
+              cat /proc/self/limits | grep -F 'Max locked memory' 1>&2
+
+              export POD_INDEX="$(echo $POD_NAME | awk -F'-' '{print $NF}')"
               exec /firebolt-core/firebolt-core --node $POD_INDEX
           ports:
             - name: http-query
@@ -86,19 +119,95 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-            - name: firebolt-core-data
+            - name: firebolt-core-data{{ if .Values.nonRoot }}-nr{{ end }}
               mountPath: /firebolt-core/volume
             - name: nodes-config
               mountPath: /firebolt-core/config.json
               subPath: config.json
               readOnly: true
           securityContext:
-            {{- toYaml $.Values.deployment.securityContext | nindent 12 }}
+            readOnlyRootFilesystem: false
+            {{- if .Values.nonRoot }}
+            runAsNonRoot: true
+            runAsUser: 1111
+            runAsGroup: 1111
+            {{- end }}
+            allowPrivilegeEscalation: false
             capabilities:
-              add:
-                {{- toYaml $.Values.deployment.securityCapabilities.add | nindent 16 }}
               drop:
                 - ALL
+              add:
+                # necessary once memlock limit is already at 8gb minimum
+                - IPC_LOCK
+        {{- if .Values.memlockSetup }}
+        - name: memlock-setup
+          # use an image which has 'prlimit'
+          image: debian:stable-slim
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - SYS_RESOURCE
+          command: ["/bin/bash", "-c"]
+          args:
+          - |
+            PID_FILE=/firebolt-core/volume/entrypoint.pid
+            MAIN_PID=""
+            echo "[Setup] Waiting for entrypoint PID" 1>&2
+            while [ -z "$MAIN_PID" ]; do
+              if [ -f $PID_FILE ]; then
+                MAIN_PID="$(< $PID_FILE)"
+                if [ -n "$MAIN_PID" ]; then
+                  if [ -d /proc/$MAIN_PID ]; then
+                    break
+                  else
+                    # it's a leftover from previous runs
+                    MAIN_PID=""
+                  fi
+                fi
+              fi
+              sleep 0.2
+            done
+            echo "[Setup] Core PID is $MAIN_PID" 1>&2
+
+            REQUIRED_MEMLOCK_BYTES=8589934592 # 8GB
+            # Expected: 'unlimited' or a number in bytes.
+            CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
+            echo "[Setup] current soft memlock limit: $CURRENT_MEMLOCK_VALUE" 1>&2
+
+            if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
+              echo "[Setup] current memlock limit is 'unlimited'. No change needed." 1>&2
+            else
+              if [ "$CURRENT_MEMLOCK_VALUE" -lt "$REQUIRED_MEMLOCK_BYTES" ]; then
+                echo "[Setup] current limit ($CURRENT_MEMLOCK_VALUE bytes) is below required 8GB, setting a higher limit" 1>&2
+
+                if prlimit --pid $MAIN_PID --memlock=$REQUIRED_MEMLOCK_BYTES:$REQUIRED_MEMLOCK_BYTES; then
+                  echo "[Setup] successfully set memlock limit for PID $MAIN_PID" 1>&2
+                else
+                  echo "[Setup] failed to set memlock prlimit. Check capabilities or node configuration." 1>&2
+                  exit 1
+                fi
+              else
+                echo "[Setup] current memlock limit ($CURRENT_MEMLOCK_VALUE bytes) is already sufficient (>= 8GB). No change needed." 1>&2
+              fi
+            fi
+
+            rm "$PID_FILE"
+
+            echo "[Setup] idle waiting"
+            exec tail -f /dev/null
+          volumeMounts:
+            - name: firebolt-core-data{{ if .Values.nonRoot }}-nr{{ end }}
+              mountPath: /firebolt-core/volume
+        {{- end }}
       volumes:
         - name: nodes-config
           configMap:
@@ -108,6 +217,6 @@ spec:
                 path: config.json
   volumeClaimTemplates:
     - metadata:
-        name: firebolt-core-data
+        name: firebolt-core-data{{ if .Values.nonRoot }}-nr{{ end }}
       spec:
         {{- toYaml $.Values.deployment.storageSpec | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,7 +38,7 @@ deployment:
   storageSpec:
     accessModes:
       - ReadWriteOnce
-    storageClassName: gp3
+    # no storage class specified to be compatible with multiple cloud providers
     resources:
       requests:
         storage: 1Gi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,6 +10,9 @@ nodesCount: 1
 # -- readiness check on each pod
 readiness: true
 
+# -- deploy a PodMonitor for Prometheus metrics scraping
+podMonitor: false
+
 # -- resources for each pod; at least 1 core is advised
 resources:
   requests:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,6 +13,12 @@ readiness: true
 # -- deploy a PodMonitor for Prometheus metrics scraping
 podMonitor: false
 
+# -- enable non-root mode, requires a compatible Firebolt Core docker image
+nonRoot: false
+
+# -- automatically attempt to set memlock limits on container startup; not necessary if your nodes already have a large enough memlock limit.
+memlockSetup: true
+
 # -- resources for each pod; at least 1 core is advised
 resources:
   requests:
@@ -27,14 +33,7 @@ extraLabels: {}
 deployment:
   # -- give a few seconds of grace time on shutdown to allow queries to finish
   terminationGracePeriodSeconds: 5
-  # -- security context which will be used by each pod
-  securityContext:
-    readOnlyRootFilesystem: false
-  # -- security capabilities which will be used by each pod
-  securityCapabilities:
-    add:
-      - IPC_LOCK
-      - SYS_NICE
+
   storageSpec:
     accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
For ulimits (like `memlock`) in Kubernetes the standard way is to to configure the underlying container runtime (e.g., Docker, containerd) at the node level.
The ulimits field in the Pod's securityContext is unfortunately not directly available for general ulimit settings like `memlock`.

This change makes all Core containers set `memlock` limits on startup, leveraging the `SYS_RESOURCE` capability.

A new `nonRoot` mode is added, although not yet supported.
