### PR TITLE
fix: prevent old PID files causing memlock setup failures

### DIFF
--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -51,6 +51,9 @@ spec:
           args:
             - |
               REQUIRED_MEMLOCK_BYTES=8589934592 # 8GB
+              function get_memlock_limit() {
+                cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}'
+              }
 
               echo -n "[Setup] Firebolt Core version "
               /firebolt-core/firebolt-core --version
@@ -64,14 +67,15 @@ spec:
               {{- if .Values.memlockSetup }}
               echo "[Setup] Core entrypoint PID: $BASHPID"
               rm -f /firebolt-core/volume/entrypoint-*.pid
-              echo "$BASHPID" > /firebolt-core/volume/entrypoint-$POD_UID.pid
-              trap "rm /firebolt-core/volume/entrypoint-$POD_UID.pid" EXIT
+              PID_FILE="/firebolt-core/volume/entrypoint-$POD_UID.pid"
+              echo "$BASHPID" > "$PID_FILE"
+              trap "rm -f $PID_FILE" EXIT
 
               ## wait until memlock limits are changed by the helper container
-              CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
+              CURRENT_MEMLOCK_VALUE=$(get_memlock_limit)
               echo "[Setup] current soft memlock limit: $CURRENT_MEMLOCK_VALUE (will wait for limits to be upgraded if below 8GB)" 1>&2
               while true; do
-                CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
+                CURRENT_MEMLOCK_VALUE=$(get_memlock_limit)
 
                 if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
                   break
@@ -94,8 +98,10 @@ spec:
               {{- end }}
 
               {{- end }}
-              echo "[Setup] current memlock limit (running as root with IPC_LOCK, will ignore this limit):" 1>&2
+              echo "[Setup] current memlock limit:" 1>&2
               cat /proc/self/limits | grep -F 'Max locked memory' 1>&2
+
+              rm -f "$PID_FILE"
 
               export POD_INDEX="$(echo $POD_NAME | awk -F'-' '{print $NF}')"
               exec /firebolt-core/firebolt-core --node $POD_INDEX
@@ -125,6 +131,7 @@ spec:
               containerPort: 9090
               protocol: TCP
           livenessProbe:
+            initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 3
             httpGet:
@@ -188,54 +195,116 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
           - |
-            set +e
             PID_FILE="/firebolt-core/volume/entrypoint-$POD_UID.pid"
             CORE_PID=""
-            echo "[Setup] Waiting for entrypoint PID" 1>&2
-            while [ -z "$CORE_PID" ]; do
-              if [ -f $PID_FILE ]; then
-                CORE_PID="$(< $PID_FILE)"
-                if [ -n "$CORE_PID" ]; then
-                  if [ ! -d /proc/$CORE_PID ]; then
-                    echo "[Setup] Core PID is $CORE_PID, but it was not found under /proc; perhaps it was killed or there is a problem with shareProcessNamespace" 1>&2
-                    exit 2
-                  fi
 
+            function wait_for_core_pid() {
+              local DELAY="$1"
+              echo "[Setup] waiting for Core entrypoint PID" 1>&2
+              while sleep $DELAY; do
+                if [ ! -f "$PID_FILE" ]; then
+                  # file not yet created by main container
+                  echo -n .
+                  continue
+                fi
+                # PID file can disappear any moment
+                if ! PID_MT=$(stat -c %Y "$PID_FILE"); then
+                  echo "[Setup] file deleted by main container while attempting stat" 1>&2
+                  continue
+                fi
+                NOW=$(date +%s)
+                AGE=$[NOW - PID_MT]
+                if [ $AGE -gt 60 ]; then
+                  echo "[Setup] Core PID is $CORE_PID, but it it is older than 1 minute, ignoring until Core container rewrites it" 1>&2
+                  continue
+                fi
+                if ! CORE_PID="$(< $PID_FILE)"; then
+                  echo "[Setup] file deleted by main container while attempting read" 1>&2
+                  continue
+                fi
+                if [ -z "$CORE_PID" ]; then
+                  echo "[Setup] partial write results in reading of an empty file" 1>&2
+                  continue
+                fi
+
+                if [ -d /proc/$CORE_PID ]; then
                   # process exists
                   break
                 fi
-              fi
-              sleep 0.2
-            done
-            set -e
-            echo "[Setup] Core PID is $CORE_PID" 1>&2
+
+                echo "[Setup] Core PID is $CORE_PID, but it was not found under /proc; perhaps it was killed or there is a problem with shareProcessNamespace" 1>&2
+                return 2
+              done
+              echo "[Setup] Core PID is $CORE_PID" 1>&2
+
+              return 0
+            }
 
             REQUIRED_MEMLOCK_BYTES=8589934592 # 8GB
-            # Expected: 'unlimited' or a number in bytes.
-            CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
-            echo "[Setup] current soft memlock limit: $CURRENT_MEMLOCK_VALUE" 1>&2
+            function get_memlock_limit() {
+              cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}'
+            }
 
-            if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
-              echo "[Setup] current memlock limit is 'unlimited'. No change needed." 1>&2
-            else
-              if [ "$CURRENT_MEMLOCK_VALUE" -lt "$REQUIRED_MEMLOCK_BYTES" ]; then
-                echo "[Setup] current limit ($CURRENT_MEMLOCK_VALUE bytes) is below required 8GB, setting a higher limit" 1>&2
+            function needs_memlock_setup() {
+              # Expected: 'unlimited' or a number in bytes.
+              local CURRENT_MEMLOCK_VALUE=$(get_memlock_limit)
 
-                if prlimit --pid $CORE_PID --memlock=$REQUIRED_MEMLOCK_BYTES:$REQUIRED_MEMLOCK_BYTES; then
-                  echo "[Setup] successfully set memlock limit for PID $CORE_PID" 1>&2
-                else
-                  echo "[Setup] failed to set memlock prlimit. Check capabilities or node configuration." 1>&2
-                  exit 1
-                fi
-              else
-                echo "[Setup] current memlock limit ($CURRENT_MEMLOCK_VALUE bytes) is already sufficient (>= 8GB). No change needed." 1>&2
+              if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
+                return 1
               fi
+              if [ "$CURRENT_MEMLOCK_VALUE" -ge "$REQUIRED_MEMLOCK_BYTES" ]; then
+                return 1
+              fi
+
+              # memlock setup is necessary
+              return 0
+            }
+
+            function adjust_memlock() {
+              local CORE_PID="$1"
+              # Expected: 'unlimited' or a number in bytes.
+              local CURRENT_MEMLOCK_VALUE=$(get_memlock_limit)
+              echo "[Setup] current soft memlock limit: $CURRENT_MEMLOCK_VALUE" 1>&2
+
+              if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
+                echo "[Setup] current memlock limit is 'unlimited'. No change needed." 1>&2
+                return 0
+              fi
+
+              if [ "$CURRENT_MEMLOCK_VALUE" -ge "$REQUIRED_MEMLOCK_BYTES" ]; then
+                echo "[Setup] current memlock limit ($CURRENT_MEMLOCK_VALUE bytes) is already sufficient (>= 8GB). No change needed." 1>&2
+                return 0
+              fi
+
+              echo "[Setup] current limit ($CURRENT_MEMLOCK_VALUE bytes) is below required 8GB, setting a higher limit" 1>&2
+
+              if prlimit --pid $CORE_PID --memlock=$REQUIRED_MEMLOCK_BYTES:$REQUIRED_MEMLOCK_BYTES; then
+                echo "[Setup] successfully set memlock limit for PID $CORE_PID" 1>&2
+                return 0
+              fi
+
+              echo "[Setup] failed to set memlock prlimit. Check capabilities or node configuration." 1>&2
+              return 1
+            }
+
+            if ! needs_memlock_setup; then
+              echo "[Setup] memlock setup not required, will be idle" 1>&2
+              exec tail -f /dev/null
             fi
 
-            rm "$PID_FILE"
+            DELAY=0.2
+            while true; do
+              wait_for_core_pid $DELAY
+              adjust_memlock $CORE_PID
 
-            echo "[Setup] idle waiting"
-            exec tail -f /dev/null
+              # wait for PID file to disappear; it is deleted by the Core container once Core starts running, or exits
+              echo "[Setup] waiting for PID file to be deleted" 1>&2
+              while [ -f "$PID_FILE" ]; do
+                sleep 0.2
+              done
+              # wait a bit longer after initial setup
+              DELAY=1
+            done
           volumeMounts:
             - name: firebolt-core-data{{ if .Values.nonRoot }}-nr{{ end }}
               mountPath: /firebolt-core/volume

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -48,6 +48,9 @@ spec:
             - |
               REQUIRED_MEMLOCK_BYTES=8589934592 # 8GB
 
+              echo -n "[Setup] Firebolt Core version "
+              /firebolt-core/firebolt-core --version
+
               echo "[Setup] entrypoint PID: $BASHPID"
               echo "$BASHPID" > /firebolt-core/volume/entrypoint.pid
 

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       securityContext:
         fsGroup: 1111
       {{- end }}
-      {{- if .Values.memlockSetup }}
+      {{- if and .Values.memlockSetup .Values.nonRoot }}
       shareProcessNamespace: true
       {{- end }}
       containers:
@@ -39,6 +39,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NODES_COUNT
               value: {{ .Values.nodesCount | quote }}
           command: ["/bin/bash", "-c"]
@@ -51,10 +55,18 @@ spec:
               echo -n "[Setup] Firebolt Core version "
               /firebolt-core/firebolt-core --version
 
-              echo "[Setup] entrypoint PID: $BASHPID"
-              echo "$BASHPID" > /firebolt-core/volume/entrypoint.pid
+              {{- if .Values.nonRoot }}
+              if [[ $(id -u) -eq 0 ]]; then
+                echo "[Setup] Core container is running as root, however deployment used nonRoot=false" 1>&2
+                exit 4
+              fi
 
               {{- if .Values.memlockSetup }}
+              echo "[Setup] Core entrypoint PID: $BASHPID"
+              rm -f /firebolt-core/volume/entrypoint-*.pid
+              echo "$BASHPID" > /firebolt-core/volume/entrypoint-$POD_UID.pid
+              trap "rm /firebolt-core/volume/entrypoint-$POD_UID.pid" EXIT
+
               ## wait until memlock limits are changed by the helper container
               CURRENT_MEMLOCK_VALUE=$(cat /proc/self/limits | grep -F 'Max locked memory' | awk '{print $4}')
               echo "[Setup] current soft memlock limit: $CURRENT_MEMLOCK_VALUE (will wait for limits to be upgraded if below 8GB)" 1>&2
@@ -63,17 +75,26 @@ spec:
 
                 if [ "$CURRENT_MEMLOCK_VALUE" = "unlimited" ]; then
                   break
-                else
-                    if [ "$CURRENT_MEMLOCK_VALUE" -lt "$REQUIRED_MEMLOCK_BYTES" ]; then
-                      sleep 0.2
-                    else
-                      echo "[Setup] current memlock limit ($CURRENT_MEMLOCK_VALUE bytes) is sufficient (>= 8GB)." 1>&2
-                      break
-                    fi
                 fi
+                if [ "$CURRENT_MEMLOCK_VALUE" -ge "$REQUIRED_MEMLOCK_BYTES" ]; then
+                  break
+                fi
+
+                sleep 0.2
               done
               {{- end }}
-              echo "[Setup] current memlock limit:" 1>&2
+              {{- else }}
+              if [[ $(id -u) -ne 0 ]]; then
+                echo "[Setup] Core container is not running as root, however deployment used nonRoot=true" 1>&2
+                exit 4
+              fi
+
+              {{- if .Values.memlockSetup }}
+              {{ fail "memlockSetup=true is unnecessary with nonRoot=false" }}
+              {{- end }}
+
+              {{- end }}
+              echo "[Setup] current memlock limit (running as root with IPC_LOCK, will ignore this limit):" 1>&2
               cat /proc/self/limits | grep -F 'Max locked memory' 1>&2
 
               export POD_INDEX="$(echo $POD_NAME | awk -F'-' '{print $NF}')"
@@ -140,9 +161,9 @@ spec:
               drop:
                 - ALL
               add:
-                # necessary once memlock limit is already at 8gb minimum
+                # IPC_LOCK is always necessary in order to use io_uring, for both the root and non-root versions
                 - IPC_LOCK
-        {{- if .Values.memlockSetup }}
+        {{- if and .Values.memlockSetup .Values.nonRoot }}
         - name: memlock-setup
           # use an image which has 'prlimit'
           image: debian:stable-slim
@@ -159,27 +180,35 @@ spec:
                 - ALL
               add:
                 - SYS_RESOURCE
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           command: ["/bin/bash", "-c"]
           args:
           - |
-            PID_FILE=/firebolt-core/volume/entrypoint.pid
-            MAIN_PID=""
+            set +e
+            PID_FILE="/firebolt-core/volume/entrypoint-$POD_UID.pid"
+            CORE_PID=""
             echo "[Setup] Waiting for entrypoint PID" 1>&2
-            while [ -z "$MAIN_PID" ]; do
+            while [ -z "$CORE_PID" ]; do
               if [ -f $PID_FILE ]; then
-                MAIN_PID="$(< $PID_FILE)"
-                if [ -n "$MAIN_PID" ]; then
-                  if [ -d /proc/$MAIN_PID ]; then
-                    break
-                  else
-                    # it's a leftover from previous runs
-                    MAIN_PID=""
+                CORE_PID="$(< $PID_FILE)"
+                if [ -n "$CORE_PID" ]; then
+                  if [ ! -d /proc/$CORE_PID ]; then
+                    echo "[Setup] Core PID is $CORE_PID, but it was not found under /proc; perhaps it was killed or there is a problem with shareProcessNamespace" 1>&2
+                    exit 2
                   fi
+
+                  # process exists
+                  break
                 fi
               fi
               sleep 0.2
             done
-            echo "[Setup] Core PID is $MAIN_PID" 1>&2
+            set -e
+            echo "[Setup] Core PID is $CORE_PID" 1>&2
 
             REQUIRED_MEMLOCK_BYTES=8589934592 # 8GB
             # Expected: 'unlimited' or a number in bytes.
@@ -192,8 +221,8 @@ spec:
               if [ "$CURRENT_MEMLOCK_VALUE" -lt "$REQUIRED_MEMLOCK_BYTES" ]; then
                 echo "[Setup] current limit ($CURRENT_MEMLOCK_VALUE bytes) is below required 8GB, setting a higher limit" 1>&2
 
-                if prlimit --pid $MAIN_PID --memlock=$REQUIRED_MEMLOCK_BYTES:$REQUIRED_MEMLOCK_BYTES; then
-                  echo "[Setup] successfully set memlock limit for PID $MAIN_PID" 1>&2
+                if prlimit --pid $CORE_PID --memlock=$REQUIRED_MEMLOCK_BYTES:$REQUIRED_MEMLOCK_BYTES; then
+                  echo "[Setup] successfully set memlock limit for PID $CORE_PID" 1>&2
                 else
                   echo "[Setup] failed to set memlock prlimit. Check capabilities or node configuration." 1>&2
                   exit 1


### PR DESCRIPTION
This PR contains 2 changes:
* prevent failure to setup memlock in case a PID file from a previous run still exists
* perform setup again in case main container (`core`) crashes
