### PR TITLE
fix: do not fail templating with root default setup

### DIFF
--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
               fi
 
               {{- if .Values.memlockSetup }}
-              {{ fail "memlockSetup=true is unnecessary with nonRoot=false" }}
+              echo "WARNING: memlockSetup=true is unnecessary with nonRoot=false" 1>&2
               {{- end }}
 
               {{- end }}


### PR DESCRIPTION
In the current transitional stage both root Core images and non-root Core images are supported; make sure that defaults work until we deprecate root Core images.