### PR TITLE
fix: remove cluster.local from node hostnames

### DIFF
--- a/helm/templates/nodes-config.yaml
+++ b/helm/templates/nodes-config.yaml
@@ -12,7 +12,7 @@ data:
         {{- $nodeCount := int .Values.nodesCount }}
         {{- range $i := until $nodeCount }}
         {
-          "host": "{{ include "fbcore.fullname" $ }}-{{ $i }}.{{ include "fbcore.fullname" $ }}-svc.{{ $.Release.Namespace }}.svc.cluster.local"
+          "host": "{{ include "fbcore.fullname" $ }}-{{ $i }}.{{ include "fbcore.fullname" $ }}-svc.{{ $.Release.Namespace }}.svc"
         }{{ if lt $i (sub $nodeCount 1) }},{{ end }}
         {{- end }}
       ]


### PR DESCRIPTION
`cluster.local` is the default search domain on most Kubernetes clusters; remove it so that non-default domains will also work (e.g. CoreDNS setups).