### PR TITLE
fix: remove unnecessary IPC_LOCK capability

### DIFF
--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -167,9 +167,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                # IPC_LOCK is always necessary in order to use io_uring, for both the root and non-root versions
-                - IPC_LOCK
         {{- if and .Values.memlockSetup .Values.nonRoot }}
         - name: memlock-setup
           # use an image which has 'prlimit'


### PR DESCRIPTION
The `IPC_LOCK` capability is not necessary for either root or non-root versions of the image.

Removing it.