### PR TITLE
feat: remove double version from labels

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Common labels
 */}}
 {{- define "fbcore.labels" -}}
 {{ include "fbcore.selectorLabels" . }}
-helm.sh/chart: {{ include "fbcore.chart" . }}-{{ .Chart.Version }}
+helm.sh/chart: {{ include "fbcore.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.extraLabels }}


### PR DESCRIPTION
Remove duplication of chart version in labels.
fbcore.chart already contains chart version and is trimmed to 64 characters. We don't need another version in "helm.sh/chart"