### PR TITLE
feat: allow passing custom node configuration

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -15,6 +15,7 @@ Firebolt Core on Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | affinity allows you to configure pod affinity and anti-affinity. See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ |
+| customNodeConfig | string | `nil` | custom configuration for nodes |
 | deployment.hostPathStorageEnabled | bool | `false` | `deployment.storageHostPath` is used instead. Only one mode is active at a time. |
 | deployment.storageHostPath | object | `{"path":"/var/lib/firebolt-core","type":"DirectoryOrCreate"}` | hostPath settings used when hostPathStorageEnabled=true |
 | deployment.storageHostPath.path | string | `"/var/lib/firebolt-core"` | path on the node's filesystem to store data |

--- a/helm/templates/nodes-config.yaml
+++ b/helm/templates/nodes-config.yaml
@@ -8,6 +8,9 @@ metadata:
 data:
   config.json: |
     {
+      {{- if .Values.customNodeConfig }}
+      {{ .Values.customNodeConfig | toJson | nindent 6 }},
+      {{- end }}
       "nodes": [
         {{- $nodeCount := int .Values.nodesCount }}
         {{- range $i := until $nodeCount }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -43,6 +43,9 @@ resources:
 # -- extra labels to assign to each pod
 extraLabels: {}
 
+# -- custom configuration for nodes
+customNodeConfig:
+
 deployment:
   # -- give a few seconds of grace time on shutdown to allow queries to finish
   terminationGracePeriodSeconds: 5


### PR DESCRIPTION
Allow experimenting with custom node configuration when deploying chart to a Kubernetes cluster.