### PR TITLE
feat: allow specification of custom init containers

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -17,6 +17,7 @@ Firebolt Core on Kubernetes
 | affinity | object | `{}` | affinity allows you to configure pod affinity and anti-affinity. See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ |
 | customInitContainers | list | `[]` | custom init containers to be injected into the pod |
 | customNodeConfig | string | `nil` | custom configuration for nodes |
+| customVolumes | list | `[]` | custom volumes to be injected into the pod |
 | deployment.hostPathStorageEnabled | bool | `false` | `deployment.storageHostPath` is used instead. Only one mode is active at a time. |
 | deployment.storageHostPath | object | `{"path":"/var/lib/firebolt-core","type":"DirectoryOrCreate"}` | hostPath settings used when hostPathStorageEnabled=true |
 | deployment.storageHostPath.path | string | `"/var/lib/firebolt-core"` | path on the node's filesystem to store data |

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -385,6 +385,9 @@ spec:
             path: {{ $.Values.deployment.storageHostPath.path }}
             type: {{ default "DirectoryOrCreate" $.Values.deployment.storageHostPath.type }}
         {{- end }}
+        {{- with .Values.customVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- if or $hpEnabled .Values.customInitContainers }}
       initContainers:
         {{- if $hpEnabled }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -66,6 +66,18 @@ customInitContainers: []
 #     image: busybox:latest
 #     command: ['sh', '-c', 'echo "Custom init container"']
 
+# -- custom volumes to be injected into the pod
+customVolumes: []
+# Example:
+# customVolumes:
+#   - name: dev
+#     hostPath:
+#       path: /dev
+#       type: Directory
+#   - name: custom-config
+#     configMap:
+#       name: my-config
+
 # -- custom configuration for nodes
 customNodeConfig:
 


### PR DESCRIPTION
Allow the definition of custom init containers; this can be useful to perform initial setup operations.