### PR TITLE
fix: tuning for liveness/readiness checks

### DIFF
--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -157,13 +157,16 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 3
+            failureThreshold: 6
             httpGet:
               path: /health/live
               port: 8122
           {{- if .Values.readiness }}
           readinessProbe:
+            initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3
+            failureThreshold: 6
             httpGet:
               path: /health/ready
               port: 8122


### PR DESCRIPTION
Use slightly better values for liveness/readiness checks.