### PR TITLE
fix: do not set ownership of all files in volume

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.5
+
+* add `fsGroupChangePolicy` value (defaults to `"OnRootMismatch"`) to speed up pod startup on large volumes
+
 # 0.3.4
 
 * fix: use priority class also for statefulsets

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 icon: https://raw.githubusercontent.com/firebolt-db/firebolt-core/refs/heads/main/static/core.svg
 home: "https://github.com/firebolt-db/firebolt-core/tree/main/helm"
 sources: ["https://github.com/firebolt-db/firebolt-core/tree/main/helm"]
-version: 0.3.4
+version: 0.3.5
 appVersion: preview-rc

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # firebolt-core
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: preview-rc](https://img.shields.io/badge/AppVersion-preview--rc-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: preview-rc](https://img.shields.io/badge/AppVersion-preview--rc-informational?style=flat-square)
 
 Firebolt Core on Kubernetes
 
@@ -27,6 +27,7 @@ Firebolt Core on Kubernetes
 | deployment.storageSpec.resources.requests.storage | string | `"1Gi"` |  |
 | deployment.terminationGracePeriodSeconds | int | `5` | give a few seconds of grace time on shutdown to allow queries to finish |
 | extraLabels | object | `{"firebolt/product":"core"}` | extra labels to assign to each pod |
+| fsGroupChangePolicy | string | `"OnRootMismatch"` | fsGroupChangePolicy defines how volume ownership is applied to pods. "OnRootMismatch" only changes permissions if the root of the volume doesn't match fsGroup, which significantly speeds up pod startup for large volumes. See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods |
 | image.pullPolicy | string | `"Always"` | imagePullPolicy for all containers in the pod |
 | image.repository | string | `"ghcr.io/firebolt-db/firebolt-core"` | use a custom ECR repository to pull the Docker image used by the pods |
 | image.tag | string | `""` | use a custom Docker image tag; when unspecified the app version from chart will be used instead |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
       {{- if $.Values.nonRoot }}
       securityContext:
         fsGroup: 1111
+        {{- if $.Values.fsGroupChangePolicy }}
+        fsGroupChangePolicy: {{ $.Values.fsGroupChangePolicy }}
+        {{- end }}
       {{- end }}
       {{- if and $.Values.memlockSetup $.Values.nonRoot }}
       shareProcessNamespace: true

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -37,6 +37,9 @@ spec:
       {{- if .Values.nonRoot }}
       securityContext:
         fsGroup: 1111
+        {{- if .Values.fsGroupChangePolicy }}
+        fsGroupChangePolicy: {{ .Values.fsGroupChangePolicy }}
+        {{- end }}
       {{- end }}
       {{- if and .Values.memlockSetup .Values.nonRoot }}
       shareProcessNamespace: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,6 +45,12 @@ podMonitor: false
 # -- enable non-root mode; set to false for Firebolt Core <= 4.29
 nonRoot: true
 
+# -- fsGroupChangePolicy defines how volume ownership is applied to pods.
+# "OnRootMismatch" only changes permissions if the root of the volume doesn't match fsGroup,
+# which significantly speeds up pod startup for large volumes.
+# See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods
+fsGroupChangePolicy: "OnRootMismatch"
+
 # -- automatically attempt to set memlock limits on container startup; not necessary if your nodes already have a large enough memlock limit.
 memlockSetup: true
 


### PR DESCRIPTION
Do not set ownership of all files in volume.
This will allow speeding up volume re-attach.