### PR TITLE
fix: data-dir and unix socket path (FB-1733)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+firebolt-core-data/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 Start Core on your machine with:
 ```bash
-bash <(curl -s https://get.firebolt.io/)
+curl -fsSL https://get.firebolt.io/ | bash
 ```
 
 If you want to work with Docker directly, you can also run on Linux:
@@ -138,7 +138,7 @@ For Kubernetes-based deployments, see the [Firebolt self-managed documentation](
 
 Software for your host OS:
 
-* **[Docker Engine](https://docs.docker.com/engine/install/)**, with the **[Docker Compose plugin](https://docs.docker.com/compose/install/linux/)** if you want to use `docker compose`; if you use `bash <(curl -s https://get.firebolt.io/)` the Docker engine will be installed automatically.
+* **[Docker Engine](https://docs.docker.com/engine/install/)**, with the **[Docker Compose plugin](https://docs.docker.com/compose/install/linux/)** if you want to use `docker compose`; if you use `curl -fsSL https://get.firebolt.io/ | bash` the Docker engine will be installed automatically.
 * **[cURL](https://curl.se/) or any other HTTP client** in order to send SQL queries to Firebolt Core.
 
 Software for your Docker host:

--- a/README.md
+++ b/README.md
@@ -57,12 +57,26 @@ Or on MacOS:
 
 ```bash
 mkdir -p -m 777 firebolt-core-data
+# On macOS the Docker Desktop file-sharing backend cannot stat the engine's Unix
+# domain socket when it lives on the bind-mounted data directory, so relocate the
+# socket onto an in-memory tmpfs at /run/firebolt via a config file.
+cat > firebolt-core-data/config.yaml <<'EOF'
+schema_version: "1.0"
+endpoints:
+  http:
+    listeners:
+      - type: tcp
+        port: 3473
+      - type: unix
+        path: /run/firebolt/query_endpoint
+EOF
 docker run -i --rm \
         --user root \
         --ulimit memlock=8589934592:8589934592 \
         --security-opt seccomp=unconfined \
         -p 127.0.0.1:3473:3473 \
         -v ./firebolt-core-data:/var/lib/firebolt \
+        --tmpfs /run/firebolt:rw,mode=2770,uid=3473,gid=0 \
         ghcr.io/firebolt-db/engine:dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ If you want to work with Docker directly, you can also run on Linux:
 
 ```bash
 docker run -i --rm \
-        -e FIREBOLT_CORE_MODE=1 \
         --ulimit memlock=8589934592:8589934592 \
         --security-opt seccomp=unconfined \
         -p 127.0.0.1:3473:3473 \
-        -v ./firebolt-core-data:/firebolt-core/volume \
+        -v ./firebolt-core-data:/var/lib/firebolt \
         ghcr.io/firebolt-db/engine:dev
 ```
 
@@ -60,11 +59,10 @@ Or on MacOS:
 mkdir -p -m 777 firebolt-core-data
 docker run -i --rm \
         --user root \
-        -e FIREBOLT_CORE_MODE=1 \
         --ulimit memlock=8589934592:8589934592 \
         --security-opt seccomp=unconfined \
         -p 127.0.0.1:3473:3473 \
-        -v ./firebolt-core-data:/firebolt-core/volume \
+        -v ./firebolt-core-data:/var/lib/firebolt \
         ghcr.io/firebolt-db/engine:dev
 ```
 
@@ -72,7 +70,7 @@ docker run -i --rm \
 > This will create a local `firebolt-core-data` directory, owned by root, where data, metadata, logs and diagnostic information are persisted.
 
 > [!NOTE]
-> Set `FIREBOLT_CORE_MODE=1` on direct `docker run` invocations. It makes the engine treat a bind-mounted `config.json` as authoritative instead of rewriting it - important when you mount your own config file read-only.
+> The Firebolt Core image stores writable state under `/var/lib/firebolt`. If you use `docker run` directly, bind mount your local data directory to `/var/lib/firebolt` to persist data across container restarts.
 
 You can also start a single node cluster by cloning this repository and then run the following command within the repository root directory:
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,10 +7,6 @@ services:
     # The Docker image from which to start the container.
     image: ${CORE_IMAGE:-ghcr.io/firebolt-db/engine:dev}
     pull_policy: always
-    # FIREBOLT_CORE_MODE=1 makes the engine treat the bind-mounted, read-only
-    # /firebolt-core/config.json as authoritative instead of rewriting it.
-    environment:
-      FIREBOLT_CORE_MODE: "1"
     # Corresponds to the `--interactive` argument passed to `docker run`.
     stdin_open: true
     healthcheck:
@@ -26,7 +22,7 @@ services:
       - -c
       - |
         # All variables defined here, and commands like id -u, stat -c, should be escaped with $$
-        VOLUME_PATH='/firebolt-core/volume'
+        VOLUME_PATH='/var/lib/firebolt'
         
         EXPECTED_UID=$$(id -u)
         EXPECTED_GID=$$(id -g)
@@ -47,7 +43,7 @@ services:
             sleep inf
         fi
         
-        exec /firebolt-core/firebolt-core --node ${NODE:-0}
+        exec firebolt server --data-dir "$${VOLUME_PATH}" --server-config /opt/firebolt/config.json --node ${NODE:-0}
 
     # Corresponds to the `--tty` argument passed to `docker run`.
     tty: true
@@ -71,9 +67,9 @@ services:
       - "9090:9090"   # Prometheus metrics.
     # Mount the configuration file at the expected location within the container. Additional storage mounts for persistent and temporary data could also be specified here.
     volumes:
-      - ${PWD}/config.json:/firebolt-core/config.json:ro
+      - ${PWD}/config.json:/opt/firebolt/config.json:ro
       # Enable persistence of data, metadata, logs and diagnostic information
-      - ${PWD}/firebolt-core-data:/firebolt-core/volume
+      - ${PWD}/firebolt-core-data:/var/lib/firebolt
   ui:
     image: ${CORE_UI_IMAGE:-ghcr.io/firebolt-db/firebolt-core-ui:latest}
     pull_policy: always

--- a/get-core.sh
+++ b/get-core.sh
@@ -45,7 +45,7 @@ DOCKER_RUN_ARGS=(
   --rm
   --ulimit memlock=8589934592:8589934592
   --security-opt seccomp=unconfined
-  -v "$(pwd)/firebolt-core-data:/firebolt-core/volume"
+  -v "$(pwd)/firebolt-core-data:/var/lib/firebolt"
   -p "$EXTERNAL_PORT:3473"
   "$DOCKER_IMAGE"
 )

--- a/get-core.sh
+++ b/get-core.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# <h2 style="color:red">Get Firebolt Core with:</h2><code>bash <(curl -s https://get-core.firebolt.io/)</code><br/><br/><br/><pre>
+# <h2 style="color:red">Get Firebolt Core with:</h2><code>curl -fsSL https://get.firebolt.io/ | bash</code><br/><br/><br/><pre>
 set -e
 
 # Parse command line arguments
@@ -138,7 +138,10 @@ run_docker_image() {
     if [ "$AUTO_RUN" = true ]; then
         answer="y"
     else
-        read -p "[🔥] Everything is set up and you are ready to go! Do you want to run the Firebolt Core image? (use --auto-run to skip this prompt) [y/N]: " answer
+        prompt="[🔥] Everything is set up and you are ready to go! Do you want to run the Firebolt Core image? (use --auto-run to skip this prompt) [y/N]: "
+        if ! { printf "%s" "$prompt" > /dev/tty && read -r answer < /dev/tty; } 2>/dev/null; then
+            answer=""
+        fi
     fi
     
     case "$answer" in

--- a/get-core.sh
+++ b/get-core.sh
@@ -45,6 +45,9 @@ CORE_REPO="${CORE_REPO:-ghcr.io/firebolt-db/engine}"
 CORE_TAG="${CORE_TAG:-dev}"
 DOCKER_IMAGE="${CORE_REPO}:${CORE_TAG}"
 EXTERNAL_PORT=3473
+# Generated engine config, dropped into the data directory (used on macOS only,
+# see below). It is auto-loaded by the engine as /var/lib/firebolt/config.yaml.
+CORE_CONFIG_FILE="firebolt-core-data/config.yaml"
 DOCKER_RUN_ARGS=(
   -i
   --name firebolt-core
@@ -53,8 +56,35 @@ DOCKER_RUN_ARGS=(
   --security-opt seccomp=unconfined
   -v "$(pwd)/firebolt-core-data:/var/lib/firebolt"
   -p "$EXTERNAL_PORT:3473"
-  "$DOCKER_IMAGE"
 )
+# On macOS the Docker Desktop file-sharing backend cannot stat the engine's Unix
+# domain socket when it lives on the bind-mounted data directory, so Core fails
+# to start. Keep the socket off the shared filesystem: put it on an in-memory
+# tmpfs at /run/firebolt and relocate it there via the generated config file.
+# Mirror the ownership/permissions the image ships /run/firebolt with
+# (firebolt:root, mode 2770) so both root and the non-root firebolt user (uid
+# 3473, group 0) can create the socket.
+if [[ $IS_MACOS -eq 1 ]]; then
+    DOCKER_RUN_ARGS+=( --tmpfs /run/firebolt:rw,mode=2770,uid=3473,gid=0 )
+fi
+DOCKER_RUN_ARGS+=( "$DOCKER_IMAGE" )
+
+# Engine config that moves the query Unix socket onto the tmpfs while keeping the
+# HTTP endpoint on TCP 3473. Used on macOS only.
+read -r -d '' CORE_CONFIG_YAML <<'EOF' || true
+schema_version: "1.0"
+endpoints:
+  http:
+    listeners:
+      - type: tcp
+        port: 3473
+      - type: unix
+        path: /run/firebolt/query_endpoint
+EOF
+
+write_core_config() {
+    printf '%s\n' "$CORE_CONFIG_YAML" > "$CORE_CONFIG_FILE"
+}
 
 ensure_docker_is_installed() {
     if docker info >/dev/null 2>&1; then
@@ -140,6 +170,9 @@ wait_for_core_to_be_ready() {
 
 run_docker_image() {
     echo "[⚠️] Note: a local 'firebolt-core-data directory' with permissions 0777 will be created."
+    if [[ $IS_MACOS -eq 1 ]]; then
+        echo "[⚠️] Note: on macOS a '$CORE_CONFIG_FILE' file will be created and the socket will run on an in-memory tmpfs."
+    fi
     
     if [[ "$AUTO_RUN" = true ]]; then
         answer="y"
@@ -152,10 +185,11 @@ run_docker_image() {
     
     case "$answer" in
         [yY])
-            if [[ $IS_MACOS -eq 0 ]]; then
-                if [[ ! -d firebolt-core-data ]]; then
-                    mkdir -p -m 777 firebolt-core-data
-                fi
+            if [[ ! -d firebolt-core-data ]]; then
+                mkdir -p -m 777 firebolt-core-data
+            fi
+            if [[ $IS_MACOS -eq 1 ]]; then
+                write_core_config
             fi
             echo -n "[🔥] Starting the Firebolt Core Docker container"
             CID="$(docker run --detach --user $CORE_USER "${DOCKER_RUN_ARGS[@]}")"
@@ -181,6 +215,11 @@ run_docker_image() {
             echo "[🔥] Firebolt Core is ready to be executed, you can do this by running the following commands:"
             echo
             echo "mkdir -m 777 firebolt-core-data"
+            if [[ $IS_MACOS -eq 1 ]]; then
+                echo "cat > $CORE_CONFIG_FILE <<'EOF'"
+                printf '%s\n' "$CORE_CONFIG_YAML"
+                echo "EOF"
+            fi
             echo "docker run --user $CORE_USER "${DOCKER_RUN_ARGS[@]}""
             echo
             echo "And then in another terminal:"

--- a/get-core.sh
+++ b/get-core.sh
@@ -4,9 +4,9 @@ set -e
 
 # Parse command line arguments
 AUTO_RUN=false
-if [ "$1" = "--auto-run" ]; then
+if [[ "$1" = "--auto-run" ]]; then
     AUTO_RUN=true
-elif [ -n "$1" ]; then
+elif [[ -n "$1" ]]; then
     echo "Unknown option: $1"
     echo "Usage: $0 [--auto-run]" 1>&2
     exit 1
@@ -14,7 +14,7 @@ fi
 
 # When the script is piped in (e.g. 'curl | bash'), stdin is not a terminal
 # and the user cannot answer prompts through it, so run without prompting.
-if [ ! -t 0 ]; then
+if [[ ! -t 0 ]]; then
     AUTO_RUN=true
 fi
 
@@ -36,7 +36,7 @@ banner() {
 }
 
 IS_MACOS=0
-if [ "$(uname)" = "Darwin" ]; then
+if [[ "$(uname)" = "Darwin" ]]; then
     IS_MACOS=1
 fi
 
@@ -62,7 +62,7 @@ ensure_docker_is_installed() {
         return 0
     fi
     
-    if [ $IS_MACOS -eq 1 ]; then
+    if [[ $IS_MACOS -eq 1 ]]; then
         echo "[🐳] Docker needs to be installed: https://docs.docker.com/desktop/setup/install/mac-install/ ❌"
     else
         echo "[🐳] Docker needs to be installed: https://docs.docker.com/desktop/setup/install/linux/ ❌"
@@ -75,9 +75,9 @@ check_docker_version() {
     # See also:
     # * https://github.com/firebolt-db/firebolt-core/issues/9
     # * https://github.com/docker/for-mac/issues/7707
-    if [ $IS_MACOS -eq 1 ]; then
+    if [[ $IS_MACOS -eq 1 ]]; then
         version=$(docker version | sed -n 's/.*Docker Desktop \([0-9.]*\).*/\1/p')
-        if [ "$version" = "4.42.1" ] || [ "$version" = "4.43.0" ] || [ "$version" = "4.43.1" ]; then
+        if [[ "$version" = "4.42.1" || "$version" = "4.43.0" || "$version" = "4.43.1" ]]; then
             echo "[❌] Firebolt Core cannot run with Docker Desktop version ${version} on Mac, as it contains a known io_uring issue; please use version 4.43.2+"
             return 1
         fi
@@ -87,7 +87,7 @@ check_docker_version() {
 pull_docker_image() {
     echo "[🐳] Pulling Firebolt Core Docker image '$DOCKER_IMAGE'"
     docker pull --quiet "$DOCKER_IMAGE"
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
         echo "[🐳] Docker image '$DOCKER_IMAGE' pulled successfully ✅"
     else
         echo "[🐳] Failed to pull Docker image '$DOCKER_IMAGE' ❌"
@@ -97,7 +97,7 @@ pull_docker_image() {
 
 DEFAULT_CORE_USER=""
 detect_firebolt_user() {
-    if [ $IS_MACOS -eq 1 ]; then
+    if [[ $IS_MACOS -eq 1 ]]; then
         DEFAULT_CORE_USER=root
     else
         DEFAULT_CORE_USER="firebolt"
@@ -118,12 +118,12 @@ wait_for_core_to_be_ready() {
     # Try for ~10 seconds to get a valid response from Core
     timeout=10
     RESPONSE="Unknown error"
-    while [ $timeout -gt 0 ]; do
+    while [[ $timeout -gt 0 ]]; do
         set +e
         RESPONSE=$(curl -s 'http://localhost:3473/?output_format=TabSeparatedWithNamesAndTypes' --data-binary "SELECT 42;")
         set -e
 
-        if [ "$RESPONSE" = $'?column?\nint\n42' ]; then
+        if [[ "$RESPONSE" = $'?column?\nint\n42' ]]; then
             echo " ✅"
             return 0
         fi
@@ -141,7 +141,7 @@ wait_for_core_to_be_ready() {
 run_docker_image() {
     echo "[⚠️] Note: a local 'firebolt-core-data directory' with permissions 0777 will be created."
     
-    if [ "$AUTO_RUN" = true ]; then
+    if [[ "$AUTO_RUN" = true ]]; then
         answer="y"
     else
         prompt="[🔥] Everything is set up and you are ready to go! Do you want to run the Firebolt Core image? (use --auto-run to skip this prompt) [y/N]: "
@@ -152,8 +152,8 @@ run_docker_image() {
     
     case "$answer" in
         [yY])
-            if [ $IS_MACOS -eq 0 ]; then
-                if [ ! -d firebolt-core-data ]; then
+            if [[ $IS_MACOS -eq 0 ]]; then
+                if [[ ! -d firebolt-core-data ]]; then
                     mkdir -p -m 777 firebolt-core-data
                 fi
             fi

--- a/get-core.sh
+++ b/get-core.sh
@@ -12,6 +12,12 @@ elif [ -n "$1" ]; then
     exit 1
 fi
 
+# When the script is piped in (e.g. 'curl | bash'), stdin is not a terminal
+# and the user cannot answer prompts through it, so run without prompting.
+if [ ! -t 0 ]; then
+    AUTO_RUN=true
+fi
+
 banner() {
     echo "
 🔥🔥🔥 Firebolt Core setup script 🔥🔥🔥
@@ -158,8 +164,18 @@ run_docker_image() {
 
             wait_for_core_to_be_ready
             
-            echo "[🔥] Running Firebolt CLI"
-            docker exec -ti $CID fb --core
+            # stdin may be the script itself (e.g. 'curl | bash'), so attach the
+            # CLI to the controlling terminal instead; without one, leave the
+            # container running in the background.
+            if { : < /dev/tty; } 2>/dev/null; then
+                echo "[🔥] Running Firebolt CLI"
+                docker exec -ti $CID fb --core < /dev/tty
+            else
+                trap - EXIT
+                echo "[🔥] No terminal available, leaving Firebolt Core running in the background."
+                echo "[🔥] Connect to it with: docker exec -ti firebolt-core fb --core"
+                echo "[🔥] Stop it with: docker kill firebolt-core"
+            fi
             ;;
         *)
             echo "[🔥] Firebolt Core is ready to be executed, you can do this by running the following commands:"


### PR DESCRIPTION
## Summary
- Update Docker examples and `get-core.sh` to bind persistent data at `/var/lib/firebolt`.
- Update `compose.yaml` for the new Core image layout: `/opt/firebolt/config.json`, `firebolt server`, and `/var/lib/firebolt`.
- Remove obsolete `FIREBOLT_CORE_MODE` usage from README and compose.

## Test plan
- `docker compose -p core-fix-validate config`
- `CORE_USER=root docker compose -p core-fix-smoke up core --detach --no-deps`
- `curl -s 'http://localhost:3473/?output_format=psql' --data-binary 'SELECT 42;'`


Made with [Cursor](https://cursor.com)