### PR TITLE
feat: remove fb-cli usage from get-core script (FB-2595)

### DIFF
--- a/get-core.sh
+++ b/get-core.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# <h2 style="color:red">Get Firebolt Core with:</h2><code>curl -fsSL https://get.firebolt.io/ | bash</code><br/><br/><br/><pre>
+# <h2 style="color:red">Get Firebolt with:</h2><code>curl -fsSL https://get.firebolt.io/ | bash</code><br /><br /><br /><pre>
 set -e
 
 # Parse command line arguments
 AUTO_RUN=false
-if [[ "$1" = "--auto-run" ]]; then
+if [ "$1" = "--auto-run" ]; then
     AUTO_RUN=true
-elif [[ -n "$1" ]]; then
+elif [ -n "$1" ]; then
     echo "Unknown option: $1"
     echo "Usage: $0 [--auto-run]" 1>&2
     exit 1
@@ -14,64 +14,64 @@ fi
 
 # When the script is piped in (e.g. 'curl | bash'), stdin is not a terminal
 # and the user cannot answer prompts through it, so run without prompting.
-if [[ ! -t 0 ]]; then
+if [ ! -t 0 ]; then
     AUTO_RUN=true
 fi
 
 banner() {
-    echo "
-🔥🔥🔥 Firebolt Core setup script 🔥🔥🔥
----------:    .---     ---------:         ---------:     ---------:              :-====-:            ---          .---------..  
-++++++++++    :+++     ++++++++++++:      +++++++++-     ++++++++++++-        ++++++++++++++     ...:=++        -+++++++++++++  
-++++          :+++     +++-     ++++.     +++-           +++-     ++++-    :=++++.      -++++=      :+++             -+++       
-++++          :+++     +++:      +++:     +++-           +++-     .:++=    ++++.          =++:      :++=             :+-:       
-++++:....     :+++     +++-     ++++      ++++:....      ++++:...-++++    .+=-             =+++     :+++             .=++       
-+++++++++     :+++     ++++++++++++       +++++++++      ++++++++++++     -+++-               -    :++++             :+++       
-++++          :+++     +++=.:+++=         +++=           +++=    .++++:    +++=           .=+++     :+++             :++=       
-++++          :+++     +++:   =++=        +++-           +++-      -++=    =+++=          ++++:     :+++            :=+++       
-++++          :+++     +++:    ++++       +++=           +++=    :++++:     -+++++:    -+++++:      -+++.            :+++       
-++++          :+++     +++:     =+++      ++++++++++       =+++++++--         -++++++++++++.        -++++++++-       .-++       
-                                                                                  .:--:.                                        
-"
+    echo -e "\e[31m"
+    echo "███████╗██╗██████╗ ███████╗██████╗  ██████╗ ██╗  ████████╗"
+    echo "██╔════╝██║██╔══██╗██╔════╝██╔══██╗██╔═══██╗██║  ╚══██╔══╝"
+    echo "█████╗  ██║██████╔╝█████╗  ██████╔╝██║   ██║██║     ██║   "
+    echo "██╔══╝  ██║██╔══██╗██╔══╝  ██╔══██╗██║   ██║██║     ██║   "
+    echo "██║     ██║██║  ██║███████╗██████╔╝╚██████╔╝███████╗██║   "
+    echo "╚═╝     ╚═╝╚═╝  ╚═╝╚══════╝╚═════╝  ╚═════╝ ╚══════╝╚═╝   "
+    echo -e "\e[0m"
+    echo "       The Analytical Database for Engineers"
+    echo "       © 2026 Firebolt Analytics Inc (https://firebolt.io)"
+    echo ""
+    echo "       🔥🔥🔥 Setup script for Firebolt 🔥🔥🔥"
+    echo ""
 }
 
 IS_MACOS=0
-if [[ "$(uname)" = "Darwin" ]]; then
+if [ "$(uname)" = "Darwin" ]; then
     IS_MACOS=1
 fi
 
 # Docker image to pull - allow specifying overrides via env variables
-CORE_REPO="${CORE_REPO:-ghcr.io/firebolt-db/engine}"
-CORE_TAG="${CORE_TAG:-dev}"
-DOCKER_IMAGE="${CORE_REPO}:${CORE_TAG}"
+ENGINE_REPO="${ENGINE_REPO:-ghcr.io/firebolt-db/engine}"
+ENGINE_TAG="${ENGINE_TAG:-dev}"
+DOCKER_IMAGE="${ENGINE_REPO}:${ENGINE_TAG}"
 EXTERNAL_PORT=3473
 # Generated engine config, dropped into the data directory (used on macOS only,
 # see below). It is auto-loaded by the engine as /var/lib/firebolt/config.yaml.
-CORE_CONFIG_FILE="firebolt-core-data/config.yaml"
+CONFIG_FILE="firebolt-data/config.yaml"
+DOCKER_CONTAINER_NAME="firebolt"
 DOCKER_RUN_ARGS=(
   -i
-  --name firebolt-core
+  --name $DOCKER_CONTAINER_NAME
   --rm
   --ulimit memlock=8589934592:8589934592
   --security-opt seccomp=unconfined
-  -v "$(pwd)/firebolt-core-data:/var/lib/firebolt"
+  -v "$(pwd)/firebolt-data:/var/lib/firebolt"
   -p "$EXTERNAL_PORT:3473"
 )
 # On macOS the Docker Desktop file-sharing backend cannot stat the engine's Unix
-# domain socket when it lives on the bind-mounted data directory, so Core fails
-# to start. Keep the socket off the shared filesystem: put it on an in-memory
-# tmpfs at /run/firebolt and relocate it there via the generated config file.
-# Mirror the ownership/permissions the image ships /run/firebolt with
-# (firebolt:root, mode 2770) so both root and the non-root firebolt user (uid
-# 3473, group 0) can create the socket.
-if [[ $IS_MACOS -eq 1 ]]; then
+# domain socket when it lives on the bind-mounted data directory, so Firebolt
+# fails to start. Keep the socket off the shared filesystem: put it on an
+# in-memory tmpfs at /run/firebolt and relocate it there via the generated
+# config file. Mirror the ownership/permissions the image ships /run/firebolt
+# with (firebolt:root, mode 2770) so both root and the non-root firebolt user
+# (uid 3473, group 0) can create the socket.
+if [ $IS_MACOS -eq 1 ]; then
     DOCKER_RUN_ARGS+=( --tmpfs /run/firebolt:rw,mode=2770,uid=3473,gid=0 )
 fi
 DOCKER_RUN_ARGS+=( "$DOCKER_IMAGE" )
 
 # Engine config that moves the query Unix socket onto the tmpfs while keeping the
 # HTTP endpoint on TCP 3473. Used on macOS only.
-read -r -d '' CORE_CONFIG_YAML <<'EOF' || true
+read -r -d '' CONFIG_YAML <<'EOF' || true
 schema_version: "1.0"
 endpoints:
   http:
@@ -82,8 +82,8 @@ endpoints:
         path: /run/firebolt/query_endpoint
 EOF
 
-write_core_config() {
-    printf '%s\n' "$CORE_CONFIG_YAML" > "$CORE_CONFIG_FILE"
+write_firebolt_config() {
+    printf '%s\n' "$CONFIG_YAML" > "$CONFIG_FILE"
 }
 
 ensure_docker_is_installed() {
@@ -91,8 +91,8 @@ ensure_docker_is_installed() {
         echo "[🐳] Docker is present and works ✅"
         return 0
     fi
-    
-    if [[ $IS_MACOS -eq 1 ]]; then
+
+    if [ $IS_MACOS -eq 1 ]; then
         echo "[🐳] Docker needs to be installed: https://docs.docker.com/desktop/setup/install/mac-install/ ❌"
     else
         echo "[🐳] Docker needs to be installed: https://docs.docker.com/desktop/setup/install/linux/ ❌"
@@ -103,21 +103,22 @@ ensure_docker_is_installed() {
 check_docker_version() {
     # Explicitly inform the user about the known io_uring issue in Docker Desktop for Mac
     # See also:
-    # * https://github.com/firebolt-db/firebolt-core/issues/9
     # * https://github.com/docker/for-mac/issues/7707
-    if [[ $IS_MACOS -eq 1 ]]; then
+    if [ $IS_MACOS -eq 1 ]; then
         version=$(docker version | sed -n 's/.*Docker Desktop \([0-9.]*\).*/\1/p')
-        if [[ "$version" = "4.42.1" || "$version" = "4.43.0" || "$version" = "4.43.1" ]]; then
-            echo "[❌] Firebolt Core cannot run with Docker Desktop version ${version} on Mac, as it contains a known io_uring issue; please use version 4.43.2+"
+        if [ "$version" = "4.42.1" ] || [ "$version" = "4.43.0" ] || [ "$version" = "4.43.1" ]; then
+            echo "[❌] Firebolt cannot run with Docker Desktop version ${version} on Mac, as it contains a known io_uring issue; please use version 4.43.2+"
             return 1
         fi
     fi
 }
 
 pull_docker_image() {
-    echo "[🐳] Pulling Firebolt Core Docker image '$DOCKER_IMAGE'"
-    docker pull --quiet "$DOCKER_IMAGE"
-    if [[ $? -eq 0 ]]; then
+    echo "[🐳] Pulling Firebolt Docker image '$DOCKER_IMAGE'"
+    # Check the pull inline rather than through '$?': 'set -e' would abort the script on a
+    # failed pull before any separate check could report it, leaving the user with docker's
+    # raw error and none of the context below.
+    if docker pull --quiet "$DOCKER_IMAGE"; then
         echo "[🐳] Docker image '$DOCKER_IMAGE' pulled successfully ✅"
     else
         echo "[🐳] Failed to pull Docker image '$DOCKER_IMAGE' ❌"
@@ -125,35 +126,35 @@ pull_docker_image() {
     fi
 }
 
-DEFAULT_CORE_USER=""
+DEFAULT_RUN_USER=""
 detect_firebolt_user() {
-    if [[ $IS_MACOS -eq 1 ]]; then
-        DEFAULT_CORE_USER=root
+    if [ $IS_MACOS -eq 1 ]; then
+        DEFAULT_RUN_USER=root
     else
-        DEFAULT_CORE_USER="firebolt"
+        DEFAULT_RUN_USER="firebolt"
     fi
 
-    # set CORE_USER, unless already set by user
-    CORE_USER="${CORE_USER:-$DEFAULT_CORE_USER}"
+    # set FIREBOLT_USER, unless already set by user
+    FIREBOLT_USER="${FIREBOLT_USER:-$DEFAULT_RUN_USER}"
 }
 
-wait_for_core_to_be_ready() {
-    # If curl is not installed, we can't check if Core is ready
+wait_for_firebolt_to_be_ready() {
+    # If curl is not installed, we can't check if Firebolt is ready
     if ! command -v curl >/dev/null 2>&1; then
         return 0
     fi
 
-    echo -n "[🔥] Wait for Firebolt Core to be ready"
-    
-    # Try for ~10 seconds to get a valid response from Core
+    echo -n "[🔥] Wait for Firebolt to be ready"
+
+    # Try for ~10 seconds to get a valid response from Firebolt
     timeout=10
     RESPONSE="Unknown error"
-    while [[ $timeout -gt 0 ]]; do
+    while [ $timeout -gt 0 ]; do
         set +e
         RESPONSE=$(curl -s 'http://localhost:3473/?output_format=TabSeparatedWithNamesAndTypes' --data-binary "SELECT 42;")
         set -e
 
-        if [[ "$RESPONSE" = $'?column?\nint\n42' ]]; then
+        if [ "$RESPONSE" = $'?column?\nint\n42' ]; then
             echo " ✅"
             return 0
         fi
@@ -163,68 +164,78 @@ wait_for_core_to_be_ready() {
     done
 
     echo " ❌"
-    echo "[❌] Firebolt Core failed to start. This is unexpected, please submit a bug report on Github https://github.com/firebolt-db/firebolt-core/issues"
+    echo "[❌] Firebolt failed to start. This is unexpected, please submit a bug report on Github https://github.com/firebolt-db/firebolt-core/issues"
     echo "[❌] Error: $RESPONSE"
     return 1
 }
 
 run_docker_image() {
-    echo "[⚠️] Note: a local 'firebolt-core-data directory' with permissions 0777 will be created."
-    if [[ $IS_MACOS -eq 1 ]]; then
-        echo "[⚠️] Note: on macOS a '$CORE_CONFIG_FILE' file will be created and the socket will run on an in-memory tmpfs."
+    echo "[⚠️] Note: a local 'firebolt-data directory' with permissions 0777 will be created."
+    if [ $IS_MACOS -eq 1 ]; then
+        echo "[⚠️] Note: on macOS a '$CONFIG_FILE' file will be created and the socket will run on an in-memory tmpfs."
     fi
-    
-    if [[ "$AUTO_RUN" = true ]]; then
+
+    if [ "$AUTO_RUN" = true ]; then
         answer="y"
     else
-        prompt="[🔥] Everything is set up and you are ready to go! Do you want to run the Firebolt Core image? (use --auto-run to skip this prompt) [y/N]: "
+        prompt="[🔥] Everything is set up and you are ready to go! Do you want to run the Firebolt image? (use --auto-run to skip this prompt) [y/N]: "
         if ! { printf "%s" "$prompt" > /dev/tty && read -r answer < /dev/tty; } 2>/dev/null; then
             answer=""
         fi
     fi
-    
+
     case "$answer" in
         [yY])
-            if [[ ! -d firebolt-core-data ]]; then
-                mkdir -p -m 777 firebolt-core-data
+            if [ ! -d firebolt-data ]; then
+                mkdir -p -m 777 firebolt-data
             fi
-            if [[ $IS_MACOS -eq 1 ]]; then
-                write_core_config
+            if [ $IS_MACOS -eq 1 ]; then
+                write_firebolt_config
             fi
-            echo -n "[🔥] Starting the Firebolt Core Docker container"
-            CID="$(docker run --detach --user $CORE_USER "${DOCKER_RUN_ARGS[@]}")"
+            echo -n "[🔥] Starting the Firebolt Docker container"
+            CID="$(docker run --detach --user $FIREBOLT_USER "${DOCKER_RUN_ARGS[@]}")"
             trap "docker kill $CID" EXIT
             echo " ✅"
 
-            wait_for_core_to_be_ready
-            
+            wait_for_firebolt_to_be_ready
+
             # stdin may be the script itself (e.g. 'curl | bash'), so attach the
             # CLI to the controlling terminal instead; without one, leave the
             # container running in the background.
+            #
+            # The image ships no separate CLI binary: `firebolt` is both the server and the
+            # client. The `client` subcommand is what connects to the server already running
+            # in the container (localhost:3473, database "firebolt") — a bare `firebolt`
+            # would start a second, embedded one instead.
             if { : < /dev/tty; } 2>/dev/null; then
                 echo "[🔥] Running Firebolt CLI"
-                docker exec -ti $CID fb --core < /dev/tty
+                docker exec -ti $CID firebolt client < /dev/tty
             else
                 trap - EXIT
-                echo "[🔥] No terminal available, leaving Firebolt Core running in the background."
-                echo "[🔥] Connect to it with: docker exec -ti firebolt-core fb --core"
-                echo "[🔥] Stop it with: docker kill firebolt-core"
+                echo "[🔥] No terminal available, leaving Firebolt running in the background."
+                echo "[🔥] Connect to it with: docker exec -ti $DOCKER_CONTAINER_NAME firebolt client"
+                echo "[🔥] Stop it with: docker kill $DOCKER_CONTAINER_NAME"
             fi
             ;;
         *)
-            echo "[🔥] Firebolt Core is ready to be executed, you can do this by running the following commands:"
+            echo "[🔥] Firebolt is ready to be executed, you can do this by running the following commands:"
             echo
-            echo "mkdir -m 777 firebolt-core-data"
-            if [[ $IS_MACOS -eq 1 ]]; then
-                echo "cat > $CORE_CONFIG_FILE <<'EOF'"
-                printf '%s\n' "$CORE_CONFIG_YAML"
+            echo "mkdir -m 777 firebolt-data"
+            if [ $IS_MACOS -eq 1 ]; then
+                echo "cat > $CONFIG_FILE <<'EOF'"
+                printf '%s\n' "$CONFIG_YAML"
                 echo "EOF"
             fi
-            echo "docker run --user $CORE_USER "${DOCKER_RUN_ARGS[@]}""
+            # Print the arguments one by one with '%q' so the line stays copy-pasteable: it
+            # quotes whatever needs quoting, e.g. the bind-mount path when the current
+            # directory contains spaces.
+            printf 'docker run --user %q' "$FIREBOLT_USER"
+            printf ' %q' "${DOCKER_RUN_ARGS[@]}"
+            printf '\n'
             echo
             echo "And then in another terminal:"
             echo
-            echo "docker exec -ti firebolt-core fb --core"
+            echo "docker exec -ti $DOCKER_CONTAINER_NAME firebolt client"
             echo
             ;;
 


### PR DESCRIPTION
Generally, update the script to the latest version. This mainly contains the rewrite to use the embedded CLI in the `firebolt` binary instead of the additional `fb` standalone CLI binary, which co-existed in the container - this one is in the deprecation process.